### PR TITLE
fix: missing remark-lint-list-item-indent in devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
     "prettier": "^3.0.0",
     "remark-cli": "^12.0.0",
     "remark-gfm": "^4.0.0",
-    "remark-preset-wooorm": "^9.0.0",
+    "remark-lint-list-item-indent": "^4.0.0",
+    "remark-preset-wooorm": "^10.0.0",
     "type-coverage": "^2.0.0",
     "typescript": "^5.0.0",
     "xo": "^0.56.0"


### PR DESCRIPTION
### Initial checklist

*   [X ] I read the support docs <!-- https://github.com/syntax-tree/.github/blob/main/support.md -->
*   [X] I read the contributing guide <!-- https://github.com/syntax-tree/.github/blob/main/contributing.md -->
*   [X] I agree to follow the code of conduct <!-- https://github.com/syntax-tree/.github/blob/main/code-of-conduct.md -->
*   [X] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Asyntax-tree&type=Issues -->
*   [X] If applicable, I’ve added docs and tests

### Description of changes

add missing remark-lint-list-item-indent to `devDependencies` in `package.json`

**Error Message:**

```sh
$ pnpm test

> mdast-zone@6.1.0 test /Users/ah/SVN-Checkouts/TST/mdast-zone
> npm run build && npm run format && npm run test-coverage


> mdast-zone@6.1.0 build
> tsc --build --clean && tsc --build && type-coverage

(385 / 385) 100.00%
type-coverage success.

> mdast-zone@6.1.0 format
> remark . -qfo && prettier . -w --log-level warn && xo --fix

readme.md
 error Cannot process file
  [cause]:
    Error: Cannot find module `remark-lint-list-item-indent`
```

<!--do not edit: pr-->
