### PR TITLE
chore: enable regex

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -39,7 +39,7 @@ import {visit} from 'unist-util-visit'
  *
  * @param {Nodes} node
  *   Tree to search.
- * @param {string} name
+ * @param {string | RegExp} name
  *   Comment name to look for.
  * @param {Handler} handler
  *   Handle a section.
@@ -57,7 +57,8 @@ export function zone(node, name, handler) {
   visit(node, function (node, index, parent) {
     const info = commentMarker(node)
     const match =
-      info && info.name === name
+      info &&
+      (typeof name === 'string' ? info.name === name : info.name.match(name))
         ? info.attributes.match(/(start|end)\b/)
         : undefined
     const type = match ? match[0] : undefined

--- a/test/fixtures/regexp/index.js
+++ b/test/fixtures/regexp/index.js
@@ -1,0 +1,16 @@
+import {zone} from 'mdast-zone'
+
+/** @param {import('mdast').Root} tree */
+export default function assertion(tree) {
+  zone(tree, /.*foo.*/, function (start, _, end) {
+    return [
+      start,
+      {
+        type: 'paragraph',
+        depth: 2,
+        children: [{type: 'text', value: 'changed'}]
+      },
+      end
+    ]
+  })
+}

--- a/test/fixtures/regexp/input.md
+++ b/test/fixtures/regexp/input.md
@@ -1,0 +1,5 @@
+# Foo
+
+<!--foo with some extra words start-->
+
+<!--foo end-->

--- a/test/fixtures/regexp/output.md
+++ b/test/fixtures/regexp/output.md
@@ -1,0 +1,7 @@
+# Foo
+
+<!--foo with some extra words start-->
+
+changed
+
+<!--foo end-->


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]).
  Leave the comments as they are: they do not show on GitHub.

  Please try to limit the scope,
  provide a general description of the changes,
  and remember it’s up to you to convince us to land it.

  We are excited about pull requests.
  Thank you!
-->

### Initial checklist

* [x] I read the support docs <!-- https://github.com/syntax-tree/.github/blob/main/support.md -->
* [x] I read the contributing guide <!-- https://github.com/syntax-tree/.github/blob/main/contributing.md -->
* [x] I agree to follow the code of conduct <!-- https://github.com/syntax-tree/.github/blob/main/code-of-conduct.md -->
* [x] I searched issues and discussions and couldn’t find anything or linked relevant results below <!-- https://github.com/search?q=user%3Asyntax-tree&type=issues and https://github.com/orgs/syntax-tree/discussions -->
* [x] I made sure the docs are up to date
* [x] I included tests (or that’s not needed)

### Description of changes

Added the ability to use a string or regex with the plugin when matching comment titles

<!--do not edit: pr-->
